### PR TITLE
Kill should send 'SIGINT' instead of 'SIGTERM'

### DIFF
--- a/lib/VideoReporter.js
+++ b/lib/VideoReporter.js
@@ -97,7 +97,7 @@ VideoReporter.prototype._stopScreencast = function(removeVideo) {
   var self = this;
 
   // Stop ffmpeg
-  self._ffmpeg.kill();
+  self._ffmpeg.kill('SIGINT');
 
   if (removeVideo) {
     debug('Removing video');


### PR DESCRIPTION
ffmpeg and avconv asks about 'ctrl+c' but child_process sends 'SIGTERM', it looks strange.